### PR TITLE
Fix data leakage

### DIFF
--- a/conf/dataset_config.yaml
+++ b/conf/dataset_config.yaml
@@ -5,73 +5,51 @@ dataset_config:
         config: "ja"
         split: "train"
         text_column: "sentence"
-        data_match_split: true
-        need_additional_split: false
       - name: "japanese-asr/ja_asr.jsut_basic5000"
         config: "default"
-        split: "test"
+        split: "train"
         text_column: "transcription"
-        data_match_split: false
-        need_additional_split: true
       - name: "google/fleurs"
         config: "ja_jp"
         split: "train"
         text_column: "raw_transcription"
-        data_match_split: true
-        need_additional_split: false
       - name: "reazon-research/reazonspeech"
         config: "tiny"
         split: "train"
         text_column: "transcription"
-        data_match_split: true
-        need_additional_split: true
   eval:
     datasets:
       - name: "mozilla-foundation/common_voice_11_0"
         config: "ja"
-        split: "validation"
+        split: "val"
         text_column: "sentence"
-        data_match_split: true
-        need_additional_split: false
       - name: "japanese-asr/ja_asr.jsut_basic5000"
         config: "default"
-        split: "test"
+        split: "eval"
         text_column: "transcription"
-        data_match_split: true
-        need_additional_split: true
       - name: "google/fleurs"
         config: "ja_jp"
-        split: "validation"
+        split: "val"
         text_column: "raw_transcription"
-        data_match_split: true
-        need_additional_split: false
       - name: "reazon-research/reazonspeech"
         config: "tiny"
-        split: "train"
+        split: "eval"
         text_column: "transcription"
-        data_match_split: false
-        need_additional_split: true
   test:
     datasets:
       - name: "mozilla-foundation/common_voice_11_0"
         config: "ja"
         split: "test"
         text_column: "sentence"
-        data_match_split: true
-        need_additional_split: false
       - name: "japanese-asr/ja_asr.jsut_basic5000"
         config: "default"
         split: "test"
         text_column: "transcription"
-        data_match_split: true
-        need_additional_split: true
       - name: "google/fleurs"
         config: "ja_jp"
         split: "test"
         text_column: "raw_transcription"
-        data_match_split: true
-        need_additional_split: false
 #      - name: "reazon-research/reazonspeech"
 #        config: "all"
-#        split: "train"
+#        split: "test"
 #        text_column: "transcription"

--- a/conf/dataset_config.yaml
+++ b/conf/dataset_config.yaml
@@ -25,7 +25,7 @@ dataset_config:
         text_column: "sentence"
       - name: "japanese-asr/ja_asr.jsut_basic5000"
         config: "default"
-        split: "eval"
+        split: "val"
         text_column: "transcription"
       - name: "google/fleurs"
         config: "ja_jp"
@@ -33,7 +33,7 @@ dataset_config:
         text_column: "raw_transcription"
       - name: "reazon-research/reazonspeech"
         config: "tiny"
-        split: "eval"
+        split: "val"
         text_column: "transcription"
   test:
     datasets:

--- a/run.sh
+++ b/run.sh
@@ -36,5 +36,6 @@ poetry run python3 main.py \
 	--overwrite_output_dir \
 	--do_train \
 	--do_eval \
+    --do_augment \
 	--predict_with_generate \
 	--use_auth_token

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,5 @@ poetry run python3 main.py \
 	--overwrite_output_dir \
 	--do_train \
 	--do_eval \
-    --do_augment \
 	--predict_with_generate \
 	--use_auth_token


### PR DESCRIPTION
Fixes the issue that Ryuji found where the 'eval' split was using the entire dataset. The issue was that we were looking for the split 'val', but for two datasets, this was called 'eval'. I've fixed the typos in this PR.

I have also reverted the previous work that tried to fix this, but introduced large changes that included a bug in the way the datasets were loaded and split. I appreciate the quick turnaround and initiative from spotting the issue to working to fix it, but I think it makes more sense to make a two-word change rather than an overhaul of the splitting logic.

Specifically,

`load_dataset` using the `split` arg will only load the splitted dataset. So if we had loaded the train dataset, which might be 60% of the entire dataset, we would end up splitting that into 80:10:10.  
The other issue with the new `need_additional_split` is that the pre-split datasets were not split in the consistent splits we wanted. From what I remember, the splits were imprecise to any fraction and felt arbitrary.
These are the reasons why when I worked on this, I decided to forgo downloading the datasets using the pre-split categories, and just download the entire thing (and concatenate into one dataset if they came pre-split)

Proof of fix!
<img width="1334" alt="image" src="https://github.com/user-attachments/assets/9b9b2aa1-ce3b-457d-9e06-156e0ed5536e">