### PR TITLE
Removing 'invalidated', 'reported', and 'other' examples

### DIFF
--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -74,7 +74,7 @@ def load_datasets_from_config(
         # Combine the pre-split datasets into one so we can make our own custom split
         if isinstance(dataset, dict):
             combined_dataset = concatenate_datasets(
-                [dataset[key] for key in dataset.keys()]
+                [dataset[key] for key in dataset.keys() if key != "invalidated" and key != "other" and key != "reported"]
             )
             dataset = combined_dataset
 


### PR DESCRIPTION
This change shrinks common voice 11 from 19204->15594 examples.
This means our CV dataset will only contain reviewed examples. Our other datasets don't have these categories so are unaffected.

I am also omitting examples under 'other'. These examples are unreviewed, so we might benefit from including them, but there were only 1146 examples of this category, so I've removed them for now. It's easy to add them back, so we can do that at any time.