### PR TITLE
Save checkpoint limiting for LoRA

### DIFF
--- a/main.py
+++ b/main.py
@@ -307,7 +307,7 @@ def main():
             else None
         ),
         callbacks=(
-            [ShuffleCallback(), SavePeftModelCallback()]
+            [ShuffleCallback(), SavePeftModelCallback(save_total_limit=training_args.save_total_limit)]
             if model_args.use_lora
             else [ShuffleCallback()]
         ),


### PR DESCRIPTION
## What
* To save diskspace, we implement save limits for LoRA as well.
* This takes in args.save_limit_total argument. (same as e2e)

