### PR TITLE
Spec augment

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,6 +169,10 @@ def main():
         if hasattr(training_args, "activation_dropout")
         else 0.1
     )
+    # add spec augment. for now default parameters will be used.
+    model.config.apply_spec_augment = (
+        True if hasattr(training_args, "apply_spec_augment") else False
+    )
 
     # init processor and data collator
     feature_extractor.save_pretrained(training_args.output_dir)
@@ -330,6 +334,7 @@ def main():
             "dropout": model.config.dropout,
             "attention_dropout": model.config.attention_dropout,
             "activation_dropout": model.config.activation_dropout,
+            "apply_spec_augment": model.config.apply_spec_augment,
         },
     )
 

--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,7 @@ poetry run python3 main.py \
 	--dropout="0.2" \
 	--attention_dropout="0.2" \
 	--activation_dropout="0.2" \
+	--apply_spec_augment \
 	--load_best_model_at_end \
 	--gradient_checkpointing \
 	--fp16 \

--- a/schemas/args.py
+++ b/schemas/args.py
@@ -173,6 +173,10 @@ class DataTrainingArguments:
         default=0.1,
         metadata={"help": "Dropout probability for activation layers"},
     )
+    apply_spec_augment: bool = field(
+        default=False,
+        metadata={"help": "Apply spec augment"},
+    )
     # weight_decay: float = field(
     #     default=0.01,
     #     metadata={"help": "Weight decay for AdamW optimizer"},

--- a/scripts/no_reg.sh
+++ b/scripts/no_reg.sh
@@ -31,6 +31,7 @@ poetry run python3 main.py \
 	--dropout="0" \
 	--attention_dropout="0" \
 	--activation_dropout="0" \
+	--apply_spec_augment \
 	--load_best_model_at_end \
 	--gradient_checkpointing \
 	--fp16 \

--- a/scripts/with_lora.sh
+++ b/scripts/with_lora.sh
@@ -31,6 +31,7 @@ poetry run python3 main.py \
 	--dropout="0.2" \
 	--attention_dropout="0.2" \
 	--activation_dropout="0.2" \
+	--apply_spec_augment \
 	--load_best_model_at_end \
 	--gradient_checkpointing \
 	--fp16 \

--- a/scripts/with_reg.sh
+++ b/scripts/with_reg.sh
@@ -31,6 +31,7 @@ poetry run python3 main.py \
 	--dropout="0" \
 	--attention_dropout="0" \
 	--activation_dropout="0" \
+	--apply_spec_augment \
 	--load_best_model_at_end \
 	--gradient_checkpointing \
 	--fp16 \

--- a/src/viz.py
+++ b/src/viz.py
@@ -32,7 +32,8 @@ class Visualization():
 
         self.column_mapping = {
             "loss": ["train_loss", "eval_loss"],
-            "metrics": ["eval_wer", "eval_cer"]
+            "metrics": ["eval_wer", "eval_cer"],
+            "learning_rate": ["learning_rate"]
         }
 
     def _prepare_data(self):
@@ -51,7 +52,7 @@ class Visualization():
 
         return df
 
-    def save_image(self, plot_type:Literal["loss", "metrics"]):
+    def save_image(self, plot_type:Literal["loss", "metrics", "learning_rate"]):
         """Save given type of line chart"""
         defined_plot_type = set(self.column_mapping.keys())
 


### PR DESCRIPTION
Spec Augment option was available in [WhisperConfig](https://github.com/huggingface/transformers/blob/98e8062df3cf82b367e8a243963e4afb0d9d3407/src/transformers/models/whisper/configuration_whisper.py#L142C9-L142C27) class, so I added it in as well. (Setting this argument looks like triggering this [masking function](https://github.com/huggingface/transformers/blob/98e8062df3cf82b367e8a243963e4afb0d9d3407/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py#L1231) under the hood)

Currently if `apply_spec_augment` option is specified in `run.sh`, it applies masking to the mel-log spectrum using default setting as below:

```
mask_time_prob : 0.05
mask_time_length : 10
mask_time_min_masks : 2
mask_feature_prob : 0.0:
mask_feature_length : 10:
 mask_feature_min_masks : 0
 ```
 
 I figured the effect of this augmentation does not have significant effect compared to other important hyper parameters we should focus due to time constraint, so I just decided to omit them to stick with default so we can just compare with the augmentation on and off. 